### PR TITLE
Barteron deals and details

### DIFF
--- a/components/en/developers/modules/ROOT/pages/barteron.adoc
+++ b/components/en/developers/modules/ROOT/pages/barteron.adoc
@@ -178,28 +178,11 @@ Barteron транзакции имеют переходную форму пер�
 > /rpc/getbarteronfeed <REQUEST_JSON>
 {
   "result": "success",
-    "data": {
-      "offers": [
-        { offer_instance },
-        { offer_instance },
-        ...
-      ],
-      "offerScores": [
-        { score_tx },
-        { score_tx },
-        ...
-      ],
-      "comments": [
-        { comment_tx },
-        { comment_tx },
-        ...
-      ],
-      "commentScores": [
-        { comment_score_tx },
-        { comment_score_tx },
-        ...
-      ]
-    }
+    "data": [
+      { offer_instance },
+      { offer_instance },
+      ...
+    ]
 }
 
 
@@ -220,9 +203,6 @@ Barteron транзакции имеют переходную форму пер�
     "orderDesc": true, // true | false
 }
 ----
-
-NOTE: `offer_instance`, `score_tx`, `comment_tx`, `comment_score_tx` are just
-raw transactions and relationships between them should be built on client side.
 
 === Get potencial offer deals
 [,json]
@@ -256,3 +236,51 @@ raw transactions and relationships between them should be built on client side.
 ----
 
 NOTE: `location` is literally a regexp in the following format: A percent symbol ("%") matches any sequence of zero or more characters in the string. An underscore ("_") matches any single character in the string. Any other character matches itself or its lower/upper case equivalent (case-insensitive matching)
+
+=== Get offer details
+[,json]
+----
+> /rpc/getbarteronoffersdetails <REQUEST_JSON>
+{
+  "result": "success",
+    "data": {
+      "offerScores": [
+        { score_tx },
+        { score_tx },
+        ...
+      ],
+      "comments": [
+        { comment_tx },
+        { comment_tx },
+        ...
+      ],
+      "commentScores": [
+        { comment_score_tx },
+        { comment_score_tx },
+        ...
+      ],
+      "accounts": [
+        { account_tx_with_additional_info },
+        { account_tx_with_additional_info },
+        ...
+      ]
+    }
+}
+
+
+<REQUEST_JSON>
+{
+  "offerIds": ["offerId1", "offerId2"], // Offer ids to get details for
+  "includeAccounts": true,
+  "includeScores": true,
+  "includeComments": true,
+  "includeCommentScores": true
+}
+----
+
+NOTE: `account_tx_with_additional_info` has the same format as in getbarteronaccounts request
+
+NOTE: If `includeSmth` is not specified in request then there will be no `smth` at all in response json.
+
+NOTE: `score_tx`, `comment_tx`, `comment_score_tx` and `account_tx_with_additional_info` are just
+raw transactions and relationships between them and offers should be built on client side.

--- a/components/en/developers/modules/ROOT/pages/barteron.adoc
+++ b/components/en/developers/modules/ROOT/pages/barteron.adoc
@@ -240,10 +240,12 @@ raw transactions and relationships between them should be built on client side.
 
 <REQUEST_JSON>
 {
-    "offer": "HASH", // Offer tx hash for find deals
-    "address": "ADDRESS", // Filter potencial offers with this account address
-    "location": -1, // Count of symbols for compare locations: substr(loc1, X) == substr(loc2, X)
-    "price": -1, // Max amount of difference offer prices: abs(price1 - price2) < X
+    "addresses": ["ADDRESS1", "ADDRESS2"], // Filter potencial offers with these account addresses
+    "excludeAddresses": ["ADDRESS3", "ADDRESS4"], // Filter potencial offers by excluding offers with these addresses
+    "location": "v3g9s%", // An SQLite3 language expression to be used with `LIKE` operator when comparing locations
+    "price": -1, // Max amount of offer price
+    "mytags": [1,3,4], // Filter potencial offers by the tags they are exchangable for
+    "theirTags": [5,6,7], // Filter potencial offers by their tags
     // Pagination
     "topHeight": 100, // Top height for start pagination
     "pageStart": 0, // Number of first page
@@ -252,3 +254,5 @@ raw transactions and relationships between them should be built on client side.
     "orderDesc": true, // true | false
 }
 ----
+
+NOTE: `location` is literally a regexp in the following format: A percent symbol ("%") matches any sequence of zero or more characters in the string. An underscore ("_") matches any single character in the string. Any other character matches itself or its lower/upper case equivalent (case-insensitive matching)


### PR DESCRIPTION
- Force `getbarterondeals` to be used with standalone parameters instead of concrete offer
- Introduce `getbarteronoffersdetails` to get accounts, scores, comments and comment scores for offers
- Restore `getbarteronfeed` to return only offers. It should be used together with `getbarteronoffersdetails` to get all necessary info