### PR TITLE
[docs]: fixing MiniApps button on home page

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -8,7 +8,7 @@ actions:
     type: primary
 
   - text: Mini-Apps API
-    link: /dev/api/introduction.md
+    link: /dev/apps/miniapps/get-started.md
     type: secondary
 
 features:

--- a/docs/ru/README.md
+++ b/docs/ru/README.md
@@ -7,8 +7,8 @@ actions:
     link: /ru/dev/introduction_ru.md
     type: primary
 
-  - text: Публичный API
-    link: /ru/dev/api/introduction_ru.md
+  - text: Мини-приложения
+    link: /ru/dev/apps/miniapps/get-started_ru.md
     type: secondary
 
 features:


### PR DESCRIPTION
Fixing the correct link for when Mini Apps button is pressed on home page (English version)
Fixing the button to say "Mini Apps" and correct link for when Mini Apps button is pressed on home page (Russian version)